### PR TITLE
Add an initial section on system constraints

### DIFF
--- a/design-document.md
+++ b/design-document.md
@@ -37,34 +37,37 @@ applications may choose to utilize services implementing the specification.
 ### Data resolution limitations
 
 Privacy comes at the cost of computational complexity. While affine-aggregatable
-encodings can compute many useful statistics, they require more bandwidth and
-CPU cycles to account for finite-field arithmetic during input-validation. The
-throughput of the system bounds the volume of data processed, which is
-related to the verification circuit's complexity and the rate of verifications
-performed by each work unit in an aggregator.
+encodings (AFEs) can compute many useful statistics, they require more bandwidth
+and CPU cycles to account for finite-field arithmetic during input-validation.
+The increased work from verifying inputs decreases the throughput of the system
+or the inputs processed per unit time. Throughput is related to the verification
+circuit's complexity and the available compute-time to each aggregator.
 
-Applications that utilize proofs with a large number of multiplication gates or a high
-frequency of inputs may need to limit inputs into the system to meet bandwidth
-or compute constraints. Some methods of overcoming these limitations include
-choosing a better representation for the data or introducing sampling into the
-data collection methodology.
+Applications that utilize proofs with a large number of multiplication gates or
+a high frequency of inputs may need to limit inputs into the system to meet
+bandwidth or compute constraints. Some methods of overcoming these limitations
+include choosing a better representation for the data or introducing sampling
+into the data collection methodology.
+
+[[TODO: Discuss explicit key performance indicators, here or elsewhere.]]
 
 ### Aggregation utility and soft batch deadlines
 
-A soft real-time system should produce a response within a deadline in order to be useful. This
-constraint may be relevant when the value of an aggregate decreases over time.
+A soft real-time system should produce a response within a deadline to
+be useful. This constraint may be relevant when the value of an aggregate
+decreases over time. A missed deadline can reduce an aggregate's utility
+but not necessarily cause failure in the system.
 
-An example of a soft real-time constraint is the expectation that input data can be
-verified and aggregated in a period equal to data collection, given some
+An example of a soft real-time constraint is the expectation that input data can
+be verified and aggregated in a period equal to data collection, given some
 computational budget. Meeting these deadlines will require efficient
 implementations of the input-validation protocol. Applications might batch
 requests or utilize more efficient serialization to improve throughput.
 
 Some applications may be constrained by the time that it takes to reach a
 privacy threshold defined by a minimum number of input shares. One possible
-solution is to increase the reporting period so more samples can be collected
-before the period is over, although this may need to be balanced with the need
-to produce a response within a soft deadline.
+solution is to increase the reporting period so more samples can be collected,
+balanced against the urgency of responding to a soft deadline.
 
 ### Aggregation services may need to fulfill data integrity constraints
 
@@ -76,15 +79,17 @@ every share must be processed exactly once by all aggregators. Data integrity
 constraints may be at odds with the threat model if meeting the constraints
 requires replaying data.
 
-Invalid shares are expected when operating an aggregator and do not necessarily
-constitute failures in the protocol. However, a large number of invalid
-or identical inputs may be concerning participants in the protocol.
+Aggregator operators should expect to encounter invalid inputs during regular
+operation due to misconfigured or malicious clients. Low volumes of errors are
+tolerable; the input-verification protocol and AFEs are robust in the face of
+malformed data. Aggregators may need to detect and mitigate statistically
+significant floods of invalid or identical inputs that affect accuracy, e.g.,
+denial of service (DoS) events.
 
 Certain classes of errors do not exist in the input-validation protocol
-considered in this document. For example, errors from packet loss when clients
+considered in this document. For example, packet loss errors when clients
 make requests directly to aggregators are not relevant when the leader proxies
-requests and controls the schedule for signaling the end of the aggregation
-rounds.
+requests and controls the schedule for signaling aggregation rounds.
 
 ## System design
 

--- a/design-document.md
+++ b/design-document.md
@@ -69,7 +69,7 @@ privacy threshold defined by a minimum number of input shares. One possible
 solution is to increase the reporting period so more samples can be collected,
 balanced against the urgency of responding to a soft deadline.
 
-### Aggregation services may need to fulfill data integrity constraints
+### Data integrity constraints
 
 Data integrity concerns the accuracy and correctness of the outputs in the
 system. The integrity of the output can be influenced by an incomplete round of

--- a/design-document.md
+++ b/design-document.md
@@ -30,6 +30,62 @@ practical.]]
 
 ## System constraints
 
+Prio has inherent constraints derived from the tradeoff between privacy
+guarantees and computational complexity. These tradeoffs influence how
+applications may choose to utilize services implementing the specification.
+
+### Data types have limited resolution due to input-validation complexity
+
+Privacy comes at the cost of computational complexity. While affine-aggregatable
+encodings can compute many useful statistics, they require more bandwidth and
+CPU cycles to account for finite-field arithmetic during input-validation. The
+throughput of the system bounds the volume of data processed, which is
+proportional to the verification circuit's size and the rate of verifications
+performed by each work unit in an aggregator.
+
+Applications that utilize proofs with a large number of gates or a high
+frequency of inputs may need to limit inputs into the system to meet bandwidth
+or compute constraints. Some methods of overcoming these limitations include
+choosing a better representation for the data or introducing sampling into the
+data collection methodology.
+
+### Aggregation services may need to fulfill near-real-time constraints
+
+A near-real-time system must produce a response within a deadline. This
+constraint may be relevant when the value of an aggregate decreases over time.
+
+An example of a near-real-time constraint is the expectation that a can be
+verified and aggregated in a period equal to data collection, given some
+computational budget. Meeting these deadlines may require efficient
+implementations of the input-validation protocol. Applications might batch
+requests and utilize binary serialization to improve throughput.
+
+Some applications may be constrained by the time that it takes to reach a
+privacy threshold defined by a minimum number of input shares. One possible
+solution is to increase the reporting period so more samples can be collected
+before the period is over, although this may need to be balanced with the need
+to produce a response within a deadline.
+
+### Aggregation services may need to fulfill data integrity constraints
+
+Data integrity concerns the accuracy and correctness of the outputs in the
+system. The integrity of the output can be influenced by an incomplete round of
+aggregation caused by network partitions, or by bad actors attempting to cause
+inaccuracies in the aggregates. An example data integrity constraint may be that
+every share must be processed at most once by all aggregators. Data integrity
+constraints may be at odds with the threat model if meeting the constraints
+requires replaying data.
+
+Invalid shares are expected when operating an aggregator and do not necessarily
+constitute failures in the protocol. However, a large number of invalid
+or identical inputs may be concerning participants in the protocol.
+
+Certain classes of errors do not exist in the input-validation protocol
+considered in this document. For example, errors from packet loss when clients
+make requests directly to aggregators are not relevant when the leader proxies
+requests and controls the clock cycle for signaling the end of the aggregation
+rounds.
+
 ## System design
 
 ## Open questions and system parameters

--- a/design-document.md
+++ b/design-document.md
@@ -34,45 +34,45 @@ Prio has inherent constraints derived from the tradeoff between privacy
 guarantees and computational complexity. These tradeoffs influence how
 applications may choose to utilize services implementing the specification.
 
-### Data types have limited resolution due to input-validation complexity
+### Data resolution limitations
 
 Privacy comes at the cost of computational complexity. While affine-aggregatable
 encodings can compute many useful statistics, they require more bandwidth and
 CPU cycles to account for finite-field arithmetic during input-validation. The
 throughput of the system bounds the volume of data processed, which is
-proportional to the verification circuit's size and the rate of verifications
+related to the verification circuit's complexity and the rate of verifications
 performed by each work unit in an aggregator.
 
-Applications that utilize proofs with a large number of gates or a high
+Applications that utilize proofs with a large number of multiplication gates or a high
 frequency of inputs may need to limit inputs into the system to meet bandwidth
 or compute constraints. Some methods of overcoming these limitations include
 choosing a better representation for the data or introducing sampling into the
 data collection methodology.
 
-### Aggregation services may need to fulfill near-real-time constraints
+### Aggregation utility and soft batch deadlines
 
-A near-real-time system must produce a response within a deadline. This
+A soft real-time system should produce a response within a deadline in order to be useful. This
 constraint may be relevant when the value of an aggregate decreases over time.
 
-An example of a near-real-time constraint is the expectation that a can be
+An example of a soft real-time constraint is the expectation that input data can be
 verified and aggregated in a period equal to data collection, given some
-computational budget. Meeting these deadlines may require efficient
+computational budget. Meeting these deadlines will require efficient
 implementations of the input-validation protocol. Applications might batch
-requests and utilize binary serialization to improve throughput.
+requests or utilize more efficient serialization to improve throughput.
 
 Some applications may be constrained by the time that it takes to reach a
 privacy threshold defined by a minimum number of input shares. One possible
 solution is to increase the reporting period so more samples can be collected
 before the period is over, although this may need to be balanced with the need
-to produce a response within a deadline.
+to produce a response within a soft deadline.
 
 ### Aggregation services may need to fulfill data integrity constraints
 
 Data integrity concerns the accuracy and correctness of the outputs in the
 system. The integrity of the output can be influenced by an incomplete round of
 aggregation caused by network partitions, or by bad actors attempting to cause
-inaccuracies in the aggregates. An example data integrity constraint may be that
-every share must be processed at most once by all aggregators. Data integrity
+inaccuracies in the aggregates. An example data integrity constraint is that
+every share must be processed exactly once by all aggregators. Data integrity
 constraints may be at odds with the threat model if meeting the constraints
 requires replaying data.
 
@@ -83,7 +83,7 @@ or identical inputs may be concerning participants in the protocol.
 Certain classes of errors do not exist in the input-validation protocol
 considered in this document. For example, errors from packet loss when clients
 make requests directly to aggregators are not relevant when the leader proxies
-requests and controls the clock cycle for signaling the end of the aggregation
+requests and controls the schedule for signaling the end of the aggregation
 rounds.
 
 ## System design


### PR DESCRIPTION
This PR adds a draft of system constraints. I had difficulty finding example documents to lend structure here, so apologies if the style or ideas are off the rails.

I've added three constraints that should be relevant to future discussions: data resolution, timeliness, and integrity. I'm likely missing others. Some of the text involves services or applications that implement/use Prio -- I'm not sure if it's appropriate for this document. 