### PR TITLE
Specify the ingestion flow

### DIFF
--- a/design-document.md
+++ b/design-document.md
@@ -295,7 +295,7 @@ task IDs to be sparse.]]
 ### Discovery
 
 To begin, the client first needs to discover the parameters and the URL of each
-helper. The client sends a GET request to `[leader]/parameters`. The leader
+helper. The client sends a POST request to `[leader]/upload`. The leader
 responds with status 200 and the following message body:
 
 ```
@@ -399,13 +399,13 @@ opaque PALeaderShare<0..2^24-1>;
 ```
 
 **Response.**
-The leader handles POST requests to `[leader]/upload` as follows. It first
-checks the request for a well-formed `PAUpload` message. If not found, then the
-leader aborts and alerts the client with "malformed upload".  It then looks up
-the PA parameters `PAParam` for which `PAUpload.task == PAParam.task` and
-`PAUpload.helper_url` is in `PAParam.helper_urls`. If none are found, then the
-leader aborts and alerts the client with "unrecognized task". Otherwise, if the
-upload is well-formed and contains a recognized PA task, then the leader
+The leader handles POST requests to `[leader]/upload_finish` as follows. It
+first checks the request for a well-formed `PAUpload` message. If not found,
+then the leader aborts and alerts the client with "malformed upload".  It then
+looks up the PA parameters `PAParam` for which `PAUpload.task == PAParam.task`
+and `PAUpload.helper_url` is in `PAParam.helper_urls`. If none are found, then
+the leader aborts and alerts the client with "unrecognized task". Otherwise, if
+the upload is well-formed and contains a recognized PA task, then the leader
 responds to the GET request with status 200.
 
 ### Verify Start

--- a/design-document.md
+++ b/design-document.md
@@ -38,7 +38,7 @@ document.
 1. False input: An input that is valid, but incorrect. For example, if the data
    being gathered is whether or not users have clicked on a particular button, a
    client could report clicks when none occurred.
-1. Helper: An aggreegator that is not a leader.
+1. Helper: An aggregator that is not the leader.
 1. Input: The original data emitted by a client, before any encryption or secret
    sharing scheme is applied. This may include multiple measurements.
 1. Input share: one of the shares output by feeding an input into a secret
@@ -243,15 +243,16 @@ sign its messages directly, as in Prio v2.]]
 
 Data ingestion involves the client uploading its secret shared inputs and the
 aggregators collectively validating the corresponding input. Before this process
-begins, the following must be true (the acronym "PA" stands for "Private
-Aggregation"):
+begins, the following criteria must be true (the acronym "PA" stands for
+"Private Aggregation"):
 1. The client knows the URL of the leader endpoint, e.g., `example.com/metrics`.
    We write this URL as `[leader]` below. (We write `[helper]` for the helper's
    URL and `[aggregator]` for the URL of some aggregator.)
 1. The client and leader can establish a leader-authenticated TLS channel.
-1. The leader can each helper can establish a leader-authenticated TLS channel.
-1. The helper has chosen an HPKE key pair.
-1. The aggregators agree on the PA parameters associated with a given PA task.
+1. The leader and each helper can establish a leader-authenticated TLS channel.
+1. Each helper has chosen an HPKE key pair.
+1. The aggregators agree on a set of PA tasks, as well as the PA protocol and
+   parameters used for each task.
 
 The PA parameters are structured as follows:
 


### PR DESCRIPTION
Specifies the ingestion flow, including parameter discovery, uploading of shares, and validating of the shares. The same flow applies to both Prio and heavy hitters ("Hits"). The protocol-specific messages are left unspecified. (We will specify them in future PRs.)

Note that I decided to go with TLS syntax for this PR. This was done only because I'm familiar with this style and it was easy for me to write quickly. I'm happy to completely re-do message encoding, but let's do so in a future PR.

Issues addressed by this change:
* Closes #4: In this design, the leader specifies any number of helpers. For each helper, the client initiates a run of the protocol with the leader and the helper. This allows the a helper to drop out without impacting data processing later on. However, the leader cannot drop out. (This seems OK, since this is the same up-time requirement as usual.)
* Addresses #8. In this design, the joint randomness needed for a run of the protocol is picked by the leader and sent to the helpers in the `PAVerifyStartReq` message.
* Closes #9. In this design, the leader tells the client the URL of each helper. The client gets each helper's public key by making an HTTP request.
* Addresses #18. This PR specifies a high-level flow that should fit the input-validation protocol for heavy hitters.
* Closes #21. Any protocol-specific parameters are carried by the `PAClientParam` message.
* Addresses #22. In this design, multiple protocol runs are used to add resilience to aggregator drop-out. We still don't know whether we can use threshold secret sharing (i.e., Shamir) for the same purpose. (In any case, this design disallows it.) We should think about whether this works before closing that issue.