### PR TITLE
remove reference to core@ietf.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,16 +16,7 @@ You agree to comply with all applicable IETF policies and procedures, including,
 BCP 78, 79, the TLP, and the TLP rules regarding code components (e.g. being
 subject to a Simplified BSD License) in Contributions.
 
-
 ## Other Resources
-
-Discussion of this work occurs on the
-[core working group mailing list](https://mailarchive.ietf.org/arch/browse/core/)
-([subscribe](https://www.ietf.org/mailman/listinfo/core)).  In addition to
-contributions in GitHub, you are encouraged to participate in discussions there.
-
-**Note**: Some working groups adopt a policy whereby substantive discussion of
-technical issues needs to occur on the mailing list.
 
 You might also like to familiarize yourself with other
 [working group documents](https://datatracker.ietf.org/wg/core/documents/).


### PR DESCRIPTION
Removes a paragraph which declares that Prio work is being discussed on
any IETF mailing list, which is not (currently) the case.

Resolves #41