### PR TITLE
Add a TODO for resolving aggregate consistency

### DIFF
--- a/draft-pda-protocol.md
+++ b/draft-pda-protocol.md
@@ -573,6 +573,11 @@ The leader responds to well-formed requests to `[leader]/upload_finish` with
 status 200 and an empty body. Malformed requests are handled as described in
 {{pa-error-common-aborts}}.
 
+[TODO: Since we're running the protocol with multiple cohorts of aggregators, the
+collector needs to decide how to pick which cohort has the "correct" output.
+This might be the cohort with the largest batch of inputs. Figure this out once
+the collection is specified.]
+
 ## Verify {#pa-verify}
 
 [TODO: Add an illustration of this sub-protocol.]


### PR DESCRIPTION
Addresses #4 by adding a TODO. With #43 this issue has been solved in part: To ensure consistency in case of helper failure, the leader specifies a set of helpers, and the client runs the protocol with the leader and each helper. Each cohort produces an output, and the collector will need a way of deciding which output is "correct". Let's wait to answer this question until we close #51.