### PR TITLE
Add a length field to PAParam

### DIFF
--- a/draft-pda-protocol.md
+++ b/draft-pda-protocol.md
@@ -363,6 +363,7 @@ struct {
   uint64 batch_size;
   uint64 batch_window;
   PAProto proto;
+  uint16 length; // Length of the remainder.
   select (PAClientParam.proto) {
     case prio: PrioParam;
     case hits: HitsParam;


### PR DESCRIPTION
Closes #66.

This ensures that this structure can be parsed once we add more PAProto variants.