### PR TITLE
Add differential privacy as a threat mitigation

### DIFF
--- a/draft-pda-protocol.md
+++ b/draft-pda-protocol.md
@@ -48,6 +48,20 @@ informative:
       -ins: N. Gilboa
       -ins: Y. Ishai
 
+  JD02:
+    title: "The Sybil Attack"
+    date: 2022-10-10
+    target: "https://link.springer.com/chapter/10.1007/3-540-45748-8_24"
+    author:
+      -ins: J. Douceur
+
+  SV16:
+    title: "The Complexity of Differential Privacy"
+    date: 2016-08-09
+    target: "https://privacytools.seas.harvard.edu/files/privacytools/files/complexityprivacy_1.pdf"
+    author:
+      -ins: S. Vadhan
+
 normative:
 
   FIPS180-4:
@@ -1175,6 +1189,7 @@ mitigations available to aggregators also apply to the leader.
 1. Known input injection. Collectors may collude with clients to send known
    input to the aggregators, allowing collectors to shrink the effective
    anonymity set by subtracting the known inputs from the final output.
+   Sybil attacks {{JD02}} could be used to amplify this capability.
 
 #### Mitigations
 
@@ -1260,14 +1275,13 @@ choose minimum batch sizes.
 ## Differential privacy {#dp}
 
 Optionally, PDA deployments can choose to ensure their output F achieves
-[differential privacy](https://en.wikipedia.org/wiki/Differential_privacy).
-A simple approach would require the aggregators to add two-sided
-noise (e.g. sampled from a two-sided geometric distribution) to outputs.
-Since each aggregator is adding noise independently, privacy can be guaranteed
-even if all but one of the aggregators is malicious. Differential privacy is a strong
-privacy definition, and protects users in extreme circumstances: Even if an
-adversary has prior knowledge of every input in a batch except for one, that
-one record is still protected.
+differential privacy {{SV16}}. A simple approach would require the aggregators
+to add two-sided noise (e.g. sampled from a two-sided geometric distribution)
+to outputs. Since each aggregator is adding noise independently, privacy can be
+guaranteed even if all but one of the aggregators is malicious. Differential
+privacy is a strong privacy definition, and protects users in extreme
+circumstances: Even if an adversary has prior knowledge of every input in a
+batch except for one, that one record is still protected.
 
 ## Multiple protocol runs
 

--- a/draft-pda-protocol.md
+++ b/draft-pda-protocol.md
@@ -1099,8 +1099,8 @@ can defeat privacy by leaking input outside of the Prio system.
 1. The input validation protocol executed by the aggregators prevents either
 individual clients or coalitions of clients from compromising the robustness
 property.
-1. If aggregator output satisifes [differential privacy](#differential-privacy)
-then all records not leaked by malicious clients are still protected.
+1. If aggregator output satisifes differential privacy {{dp}}, then all records
+not leaked by malicious clients are still protected.
 
 ### Aggregator
 
@@ -1161,9 +1161,8 @@ mitigations available to aggregators also apply to the leader.
 
 1. Aggregators enforce agreed upon minimum aggregation thresholds to prevent
    deanonymizing.
-1. If aggregator output satisifes [differential privacy](#differential-privacy)
-   then genuine records are protected regardless of the size of the anonymity
-   set.
+1. If aggregator output satisifes differential privacy {{dp}}, then genuine
+   records are protected regardless of the size of the anonymity set.
 
 ### Collector
 
@@ -1181,9 +1180,8 @@ mitigations available to aggregators also apply to the leader.
 
 1. Aggregators should refuse shared parameters that are trivially insecure
    (i.e., aggregation threshold of 1 contribution).
-1. If aggregator output satisifes [differential privacy](#differential-privacy)
-   then genuine records are protected regardless of the size of the anonymity
-   set.
+1. If aggregator output satisifes differential privacy {{dp}}, then genuine
+   records are protected regardless of the size of the anonymity set.
 
 ### Aggregator collusion
 
@@ -1259,7 +1257,7 @@ but server implementations may also opt out of participating in a PDA task if
 the minimum batch size is too small. This document does not specify how to
 choose minimum batch sizes.
 
-## Differential privacy
+## Differential privacy {#dp}
 
 Optionally, PDA deployments can choose to ensure their output F achieves
 [differential privacy](https://en.wikipedia.org/wiki/Differential_privacy).

--- a/draft-pda-protocol.md
+++ b/draft-pda-protocol.md
@@ -1044,7 +1044,7 @@ secure and mutually authenticated channels. In practice, this can be done by TLS
 or some other form of application-layer authentication.
 
 In the presence of this adversary, Prio provides two important properties for
-computing an aggergation function F:
+computing an aggregation function F:
 
 1. Privacy. The aggregators and collector learn only the output of F computed
    over all client inputs, and nothing else.
@@ -1085,13 +1085,8 @@ exchanged all shared parameters over some unspecified secure channel.
 #### Capabilities
 
 1. Individual users can reveal their own input and compromise their own privacy.
-     * Since this does not affect the privacy of others in the system, it is
-       outside the threat model.
 1. Clients (that is, software which might be used by many users of the system)
 can defeat privacy by leaking input outside of the Prio system.
-     * In the current threat model, other participants have no insight into what
-       clients do besides uploading input shares. Accordingly, such attacks are
-       outside of the threat model.
 1. Clients may affect the quality of aggregations by reporting false input.
      * Prio can only prove that submitted input is valid, not that it is true.
        False input can be mitigated orthogonally to the Prio protocol (e.g., by
@@ -1104,6 +1099,8 @@ can defeat privacy by leaking input outside of the Prio system.
 1. The input validation protocol executed by the aggregators prevents either
 individual clients or coalitions of clients from compromising the robustness
 property.
+1. If aggregator output satisifes [differential privacy](#differential-privacy)
+then all records not leaked by malicious clients are still protected.
 
 ### Aggregator
 
@@ -1164,6 +1161,9 @@ mitigations available to aggregators also apply to the leader.
 
 1. Aggregators enforce agreed upon minimum aggregation thresholds to prevent
    deanonymizing.
+1. If aggregator output satisifes [differential privacy](#differential-privacy)
+   then genuine records are protected regardless of the size of the anonymity
+   set.
 
 ### Collector
 
@@ -1173,11 +1173,17 @@ mitigations available to aggregators also apply to the leader.
    aggregations, joint randomness, arithmetic circuits).
 1. Collectors may trivially defeat availability by discarding output shares
    submitted by aggregators.
+1. Known input injection. Collectors may collude with clients to send known
+   input to the aggregators, allowing collectors to shrink the effective
+   anonymity set by subtracting the known inputs from the final output.
 
 #### Mitigations
 
 1. Aggregators should refuse shared parameters that are trivially insecure
    (i.e., aggregation threshold of 1 contribution).
+1. If aggregator output satisifes [differential privacy](#differential-privacy)
+   then genuine records are protected regardless of the size of the anonymity
+   set.
 
 ### Aggregator collusion
 
@@ -1252,6 +1258,18 @@ about individual participants. Aggregators use the batch size field of the
 but server implementations may also opt out of participating in a PDA task if
 the minimum batch size is too small. This document does not specify how to
 choose minimum batch sizes.
+
+## Differential privacy
+
+Optionally, PDA deployments can choose to ensure their output F achieves
+[differential privacy](https://en.wikipedia.org/wiki/Differential_privacy).
+A simple approach would require both the helper and leader to add two-sided
+noise (e.g. sampled from a two-sided geometric distribution) to outputs.
+Since each aggregator is adding noise independently, privacy can be guaranteed
+even if one of the aggregators is malicious. Differential privacy is a strong
+privacy definition, and protects users in extreme circumstances: Even if an
+adversary has prior knowledge of every input in a batch except for one, that
+one record is still protected.
 
 ## Multiple protocol runs
 

--- a/draft-pda-protocol.md
+++ b/draft-pda-protocol.md
@@ -1261,10 +1261,10 @@ choose minimum batch sizes.
 
 Optionally, PDA deployments can choose to ensure their output F achieves
 [differential privacy](https://en.wikipedia.org/wiki/Differential_privacy).
-A simple approach would require both the helper and leader to add two-sided
+A simple approach would require the aggregators to add two-sided
 noise (e.g. sampled from a two-sided geometric distribution) to outputs.
 Since each aggregator is adding noise independently, privacy can be guaranteed
-even if one of the aggregators is malicious. Differential privacy is a strong
+even if all but one of the aggregators is malicious. Differential privacy is a strong
 privacy definition, and protects users in extreme circumstances: Even if an
 adversary has prior knowledge of every input in a batch except for one, that
 one record is still protected.

--- a/draft-pda-protocol.md
+++ b/draft-pda-protocol.md
@@ -1281,7 +1281,12 @@ to outputs. Since each aggregator is adding noise independently, privacy can be
 guaranteed even if all but one of the aggregators is malicious. Differential
 privacy is a strong privacy definition, and protects users in extreme
 circumstances: Even if an adversary has prior knowledge of every input in a
-batch except for one, that one record is still protected.
+batch except for one, that one record is still formally protected.
+
+[OPEN ISSUE: While parameters configuring the differential privacy noise (like
+specific distributions / variance) can be agreed upon out of band by the
+aggregators and collector, there may be benefits to adding explicit protocol
+support by encoding them into `PDAParams`.]
 
 ## Multiple protocol runs
 


### PR DESCRIPTION
Differential privacy can protect against attacks where a portion of the input data is known a priori, or when the size of a batch is small. This PR adds DP as an optional mitigation for PDA deployments and lists where it helps mitigate various threats.

Additionally:
- Removes a false statement that revealing user input does not compromise other users' privacy. This is not necessarily the case (e.g. imagine if the batch size is 2 or if many users reveal their input).
- Removes a statement that clients revealing their inputs is outside the threat model (is this still relevant?)