### PR TITLE
Define "valid" collect requests

### DIFF
--- a/draft-pda-protocol.md
+++ b/draft-pda-protocol.md
@@ -625,7 +625,7 @@ Collector     Leader           Helper
   +------------->                |
   |             |  aggregate 1   |
   |             <---------------->
-  |             |     ...        |
+  |             |  ...           |
   |             |  aggregate L   |
   |             <---------------->
   |             |  output share  |
@@ -708,10 +708,6 @@ return state.Output()
 [OPEN ISSUE: Describe how intra-protocol errors yield collect errors (see
 issue#57). For example, how does a leader respond to a collect request if the
 helper drops out?]
-
-Each collect request involves one of the helpers specified by the PDA parameters.
-If more than one helper is specified, the collector may issue the requests in
-any order.
 
 ### Verifying and Aggregating Reports {#pa-aggregate}
 


### PR DESCRIPTION
This partially addresses the problem of preventing inter-batch replay attacks described by @chris-wood in #82. Along the way, clean up the description of collect requests so that it talks about protocol messages rather than API calls (as @ekr suggested).