### PR TITLE
s/pda/ppm

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Automatically generated CODEOWNERS file.
-draft-pda-protocol.md over@therainbow.net
+draft-ppm-protocol.md over@therainbow.net

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ archive.json
 report.xml
 venv/
 lib
-draft-pda-protocol.xml
+draft-ppm-protocol.xml

--- a/.targets.mk
+++ b/.targets.mk
@@ -1,0 +1,4 @@
+TARGETS_DRAFTS := draft-ppm-protocol 
+TARGETS_TAGS := 
+draft-ppm-protocol-00.md: draft-ppm-protocol.md
+	sed -e 's/draft-ppm-protocol-latest/draft-ppm-protocol-00/g' $< >$@

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is the working area for the individual Internet-Draft, "Private Data Aggregation Protocol".
 
-* [Editor's Copy](https://abetterinternet.github.io/prio-documents/#go.draft-pda-protocol.html)
-* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-pda-protocol)
-* [Compare Editor's Copy to Individual Draft](https://abetterinternet.github.io/prio-documents/#go.draft-pda-protocol.diff)
+* [Editor's Copy](https://abetterinternet.github.io/prio-documents/#go.draft-ppm-protocol.html)
+* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-ppm-protocol)
+* [Compare Editor's Copy to Individual Draft](https://abetterinternet.github.io/prio-documents/#go.draft-ppm-protocol.diff)
 
 ## Building the Draft
 

--- a/draft-ppm-protocol.md
+++ b/draft-ppm-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: "Privacy Preserving Measurement"
-docname: draft-pda-protocol-latest
+docname: draft-ppm-protocol-latest
 category: std
 ipr: trust200902
 area: ART
@@ -14,7 +14,7 @@ author:
        name: Tim Geoghegan
        organization: ISRG
        email: timgeog+ietf@gmail.com
-       
+
  -
        ins: C. Patton
        name: Christopher Patton


### PR DESCRIPTION
The draft name still has the acronym "pda" in it. Let's kill this for good.